### PR TITLE
Added skip header check flag

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -95,6 +95,9 @@ subcommands:
         - no_polish:
             long: no-polish
             help: Transliterates Unicode strings in the input file into pure ASCII, effectively removing Polish diacritics.
+        - skip_header:
+            long: skip-header
+            help: Skips header authentication
       subcommands:
         - clear:
             long: clear

--- a/src/command/submit.rs
+++ b/src/command/submit.rs
@@ -314,6 +314,7 @@ where
     };
 
     if !submit_config.to_zip
+        && !submit_config.skip_header
         && !is_header_present(
             submit_config.file().unwrap(),
             &submit_config.language.unwrap(),

--- a/src/workspace/submit_config.rs
+++ b/src/workspace/submit_config.rs
@@ -30,6 +30,8 @@ pub struct SubmitConfig {
     pub no_main: bool,
     #[merge(strategy = merge::bool::overwrite_false)]
     pub no_polish: bool,
+    #[merge(strategy = merge::bool::overwrite_false)]
+    pub skip_header: bool,
 }
 
 impl SubmitConfig {
@@ -49,6 +51,7 @@ impl SubmitConfig {
             rename_as,
             no_main: false,
             no_polish: false,
+            skip_header: false,
         }
     }
 
@@ -114,6 +117,7 @@ impl<'a> TryFrom<&'a ArgMatches<'a>> for SubmitConfig {
             to_zip: args.is_present("zip"),
             no_main: args.is_present("no_main"),
             no_polish: args.is_present("no_polish"),
+            skip_header: args.is_present("skip_header"),
         };
         x.try_set_file(args.value_of("file"))?;
         Ok(x)
@@ -274,6 +278,7 @@ mod tests {
             rename_as: "source.cpp".to_string().into(),
             no_main: true,
             no_polish: true,
+            skip_header: false,
         }
     }
 


### PR DESCRIPTION
## 
This PR introduces new flag for skipping the header check.
closes #97 

## Reason
For some Baca assignments there is no header needed 